### PR TITLE
Support for .NET 6 and 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,11 @@ jobs:
         DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
     steps:
-    - name: Setup .NET 7
+    - name: Setup .NET 8
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
-    
+        dotnet-version: 8.0.x
+
     - name: Checkout source code
       uses: actions/checkout@v3
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ _ReSharper*/
 packages/
 artifacts/
 .vscode/
+# JetBrains Rider
+.idea/
+*.sln.iml

--- a/build/build.cs
+++ b/build/build.cs
@@ -48,7 +48,7 @@ namespace build
             Target(Compile, DependsOn(Restore), () =>
             {
                 Run("dotnet",
-                    $"build {solutionName} --no-restore --framework net7.0");
+                    $"build {solutionName} --no-restore");
             });
 
             Target("ci", DependsOn("default"));

--- a/build/build.csproj
+++ b/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 

--- a/src/tailwindcss-dotnet/tailwindcss-dotnet.csproj
+++ b/src/tailwindcss-dotnet/tailwindcss-dotnet.csproj
@@ -9,6 +9,7 @@
 		<Description>
 			A dotnet tool for installing and invoking Tailwind CSS.
 		</Description>
+		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Addresses #2 by replacing  .NET 7 runtime support with .NETs 6 and 8 as [.NET 7](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) has reached end-of-life.

- changes tool project to target .NET 6 and .NET 8
- changes `build` project and ci to use .NET 8

Tested using a locally-packed tool after the changes:

```shell
# in ./tailwindcss-dotnet
bash>dotnet pack ./src/tailwindcss-dotnet/tailwindcss-dotnet.csproj -o ./artifacts --configuration Release -p:PackageVersion=1.0.1
MSBuild version 17.8.5+b5265ef37 for .NET
  Determining projects to restore...
  Restored /home/user/working/tailwindcss-dotnet/src/tailwindcss-dotnet/tailwindcss-dotnet.csproj (in 1.06 sec).
  tailwindcss-dotnet -> /home/user/tailwindcss-dotnet/src/tailwindcss-dotnet/bin/Release/net6.0/tailwindcss-dotnet.dll
  tailwindcss-dotnet -> /home/user/tailwindcss-dotnet/src/tailwindcss-dotnet/bin/Release/net8.0/tailwindcss-dotnet.dll
  Successfully created package '/home/user/working/tailwindcss-dotnet/artifacts/tailwindcss-dotnet.1.0.1.nupkg'.

# in my project dir
bash>dotnet tool install --add-source ~/tailwindcss-dotnet/artifacts/tailwindcss-dotnet.1.0.1/ tailwindcss-dotnet --version 1.0.1
You can invoke the tool from this directory using the following commands: 'dotnet tool run tailwind' or 'dotnet tailwind'.
Tool 'tailwindcss-dotnet' (version '1.0.1') was successfully installed. Entry is added to the manifest file....

bash>dotnet tool run tailwind install
Downloading tailwind cli v3.4.0 from https://github.com/tailwindlabs/tailwindcss/releases/download/v3.4.0/tailwindcss-linux-x64.
Download completed in 4.14 seconds, average speed: 9.71 MB/s         
Project file was not found. Use --project option or change current folder.

bash>
```