### PR TITLE
Fix for windows ARM architectures and to pull the latest version by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The default paths are opinionated. If you need to use custom file paths or make 
 
 ### Override Tailwind CLI version
 
-If you need to use a specific version of Tailwind CLI for your project, you can do so by specifying the version using the `--tailwindcss` option.
+If you need to use a specific version of Tailwind CLI for your project, you can do so by specifying the version using the `--tailwindcss` option. If nothing is specified then the latest release of the tailwindcss executable is pulled.
 
 For example, to use Tailwind CLI of version 3.2.1, you can use the following command:
 `tailwind build --tailwindcss v3.2.1`

--- a/src/tailwindcss-dotnet/Cli/Upstream.cs
+++ b/src/tailwindcss-dotnet/Cli/Upstream.cs
@@ -1,6 +1,7 @@
 ﻿using System.Runtime.InteropServices;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Tailwindcss.DotNetTool.Cli;
@@ -8,35 +9,48 @@ namespace Tailwindcss.DotNetTool.Cli;
 public class Upstream
 {
     private static readonly HttpClient httpClient = new HttpClient();
+    private record Release
+    {
+        [JsonPropertyName("tag_name")] public string Version { get; set; }
+        [JsonPropertyName("prerelease")] public bool IsPrerelease { get; set; }
+        [JsonPropertyName("published_at")] public DateTime PublishedAt { get; set; }
 
+    }
     public static async Task<string> GetLatestReleaseVersionAsync()
     {
-        var fallbackVersion = "v4.0.0";
+        var fallbackVersion = "v4.0.12";
         try
         {
             httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("dotnet-tailwindcss");
-            var response = await httpClient.GetAsync("https://api.github.com/repos/tailwindlabs/tailwindcss/releases/latest");
+            var response = await httpClient.GetAsync("https://api.github.com/repos/tailwindlabs/tailwindcss/releases");
             response.EnsureSuccessStatusCode();
 
-            var json = await response.Content.ReadAsStringAsync();
-            using var document = JsonDocument.Parse(json);
-            var version = document.RootElement.GetProperty("tag_name").GetString();
 
-            return version ?? fallbackVersion;
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            var releases = JsonSerializer.Deserialize<Release[]>(responseBody);
+            var latestMinorRelease =
+                releases?
+                    .Where(r => !r.IsPrerelease)
+            .Where(r => r.Version.StartsWith("v4."))
+            .OrderByDescending(r => r.PublishedAt)
+            .FirstOrDefault();
+            return latestMinorRelease?.Version ?? fallbackVersion;
         }
-       
+
         catch
         {
             return fallbackVersion;
         }
     }
-    public static string Version{ get; } = GetLatestReleaseVersionAsync().GetAwaiter().GetResult();
+    private static readonly Lazy<string> _version = new(() => GetLatestReleaseVersionAsync().GetAwaiter().GetResult());
+    public static string Version => _version.Value;
 
     public static string? GetNativeExecutableName()
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            return "tailwindcss-windows-x64.exe";
+            return RuntimeInformation.ProcessArchitecture is Architecture.Arm64 or Architecture.X64 ? "tailwindcss-windows-x64.exe" : null;
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))


### PR DESCRIPTION
This addresses https://github.com/rozumak/tailwindcss-dotnet/issues/7

It also adds support to pull he latest Tailwind version automatically if the version is not passed in